### PR TITLE
Version 0.3.2.17

### DIFF
--- a/cat.xtec.clic.JClic.yml
+++ b/cat.xtec.clic.JClic.yml
@@ -1,6 +1,6 @@
 app-id: cat.xtec.clic.JClic
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk11
@@ -36,8 +36,8 @@ modules:
         commit: 2de38d9815364a85f16b0a11eb89b1abccb28bef
         # Fetch project.
       - type: archive
-        url: https://clic.xtec.cat/dist/jclic/jclic-0.3.2.16.zip
-        sha256: f8a6cfd1e73fca10fe996da720a445aff578d44819a41e46ab4496ea5500b550    
+        url: https://clic.xtec.cat/dist/jclic/jclic-0.3.2.17.zip
+        sha256: a59b6fcd55a7b22c34015c8b2fe5eca9f101c74e457363acf3a11fc5f126c1bc    
         strip-components: 0
 
       # Setting flatpakisms


### PR DESCRIPTION
Update JClic to version 0.3.2.17 and runtime to `org.freedesktop.Platform` version 22.08
